### PR TITLE
Pin alpine down 3.22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
     pull-request-branch-name:
       separator: "-"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "alpine"
+        versions: [">=3.22.0"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,11 @@
     {
       "matchFileNames": [".github/workflows/**"],
       "pinDigests": false
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["alpine"],
+      "allowedVersions": "<3.22.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add ignore rule for Alpine >=3.22.0 in .github/dependabot.yml